### PR TITLE
Toggle Error Visibility

### DIFF
--- a/odrive-gui-testing/src/controls.py
+++ b/odrive-gui-testing/src/controls.py
@@ -116,6 +116,13 @@ def controls(odrv):
                 next_sample_time = time.monotonic() + sample_interval
 
     def show_errors():
+        # Toggle error content. If errors are already displayed, hide them...
+        if error_output.visible:
+            error_output.visible = False
+            return
+        # ... else show them.
+        error_output.visible = True
+
         errors = str(utils.format_errors(odrv, True))# Get the errors from the ODrive in format but in rich text converted to str
         # This would print fine in a console, but it's not really markdown-compatible yet (it'll print in a single line)
         # It is an indented list. To be markdown-compatible we need to add list points while respecting the indentation.
@@ -156,6 +163,7 @@ def controls(odrv):
     # Print errors below the top line of components.
     with ui.row().classes('items-center'):
         error_output = ui.markdown()  # Create an output widget for displaying errors
+        error_output.visible = False  # See show_errors for details
 
     with ui.row().classes('items-center'):
         ui.button("Axis 0 Calibration", on_click=lambda: start_calibration_0()).props('icon=build')

--- a/odrive-gui-testing/src/controls.py
+++ b/odrive-gui-testing/src/controls.py
@@ -117,6 +117,16 @@ def controls(odrv):
 
     def show_errors():
         errors = str(utils.format_errors(odrv, True))# Get the errors from the ODrive in format but in rich text converted to str
+        # This would print fine in a console, but it's not really markdown-compatible yet (it'll print in a single line)
+        # It is an indented list. To be markdown-compatible we need to add list points while respecting the indentation.
+        errors = errors.splitlines()
+        for i, e in enumerate(errors):
+            # There might be a more pythonic way for separating the whitespace padding, but I couldn't think of one...
+            j = 0
+            while e[j].isspace():
+                j += 1
+            errors[i] = e[:j] + "- " + e[j:]
+        errors = "\n".join(errors)
         error_output.set_content(errors)  # Update the output widget with the error information
 
     #Axis Calibration sequence start
@@ -143,6 +153,8 @@ def controls(odrv):
         ui.button(on_click=lambda: odrv.save_configuration()).props('icon=save flat round').tooltip('Save configuration')
         recording_button = ui.button("Start Recording", on_click=record_data).props('icon=record_voice_over flat round')
         ui.button("Show Errors", on_click=show_errors).props('icon=bug_report flat round')
+    # Print errors below the top line of components.
+    with ui.row().classes('items-center'):
         error_output = ui.markdown()  # Create an output widget for displaying errors
 
     with ui.row().classes('items-center'):


### PR DESCRIPTION
On top of my pull request #1 I added the ability to hide the errors again since, with proper list formatting, they do take up quite some space. 

With this PR the "Show Error" Button shows current errors, and if clicked again, it hides them, effectively making it a toggle button. I guess this could be solved in a nicer way, so feel free to deny this PR. 

Kind regards,
Max